### PR TITLE
Add Accept-API-Version header to /json/sessions REST call

### DIFF
--- a/lib/openam.js
+++ b/lib/openam.js
@@ -87,7 +87,8 @@ OpenAMClient.prototype.validateSession = function (sessionId) {
     return request.post(this.serverUrl + '/json/sessions/' + sessionId, {
         qs: {_action: 'validate'},
         headers: {
-            'Content-Type': 'application/json'
+            'Content-Type': 'application/json',
+            'Accept-API-Version': 'resource=1.1'
         },
         json: true
     });


### PR DESCRIPTION
I am running a locally built OpenAM instance with version 14.0.0-SNAPSHOT (commit f9c2da4a7f).

When I run the openam-agent demo and navigate to `/members` I get the following error:

```
StatusCodeError: 501 - [object Object]
    at new StatusCodeError (node-openam-agent-demo/node_modules/request-promise/lib/errors.js:26:15)
    at Request.RP$callback [as _callback] (node-openam-agent-demo/node_modules/request-promise/lib/rp.js:64:32)
    at Request.self.callback (node-openam-agent-demo/node_modules/request/request.js:186:22)
    at emitTwo (events.js:87:13)
    at Request.emit (events.js:172:7)
    at Request.<anonymous> (node-openam-agent-demo/node_modules/request/request.js:1081:10)
    at emitOne (events.js:77:13)
    at Request.emit (events.js:169:7)
    at IncomingMessage.<anonymous> (node-openam-agent-demo/node_modules/request/request.js:1001:12)
    at IncomingMessage.g (events.js:260:16)
    at emitNone (events.js:72:20)
    at IncomingMessage.emit (events.js:166:7)
    at endReadableNT (_stream_readable.js:905:12)
    at nextTickCallbackWith2Args (node.js:441:9)
    at process._tickCallback (node.js:355:17)
{
  "name": "StatusCodeError",
  "statusCode": 501,
  "message": "501 - [object Object]",
  "error": {
    "code": 501,
    "reason": "Not Implemented",
    "message": "Operation is not supported."
  },
  "options": {
    "qs": {
      "_action": "validate"
    },
    "headers": {
      "Content-Type": "application/json"
    },
    "json": true,
    "uri": "http://openam.example.com:8080/openam/json/sessions/AQIC5wM2LY4Sfcwu7reTddektA9rhw0Tzi_r-Wr1cHevSTM.*AAJTSQACMDEAAlNLABM3NTI2OTU2OTUwMTUzMDIyOTM5AAJTMQAA*",
    "method": "POST",
    "simple": true,
    "resolveWithFullResponse": false
  },
  "response": {
    "statusCode": 501,
    "body": {
      "code": 501,
      "reason": "Not Implemented",
      "message": "Operation is not supported."
    },
    "headers": {
      "cache-control": "no-cache",
      "content-api-version": "resource=2.0",
      "content-type": "application/json;charset=UTF-8",
      "transfer-encoding": "chunked",
      "date": "Wed, 09 Nov 2016 15:21:31 GMT",
      "connection": "close"
    },
    "request": {
      "uri": {
        "protocol": "http:",
        "slashes": true,
        "auth": null,
        "host": "openam.example.com:8080",
        "port": "8080",
        "hostname": "openam.example.com",
        "hash": null,
        "search": "?_action=validate",
        "query": "_action=validate",
        "pathname": "/openam/json/sessions/AQIC5wM2LY4Sfcwu7reTddektA9rhw0Tzi_r-Wr1cHevSTM.*AAJTSQACMDEAAlNLABM3NTI2OTU2OTUwMTUzMDIyOTM5AAJTMQAA*",
        "path": "/openam/json/sessions/AQIC5wM2LY4Sfcwu7reTddektA9rhw0Tzi_r-Wr1cHevSTM.*AAJTSQACMDEAAlNLABM3NTI2OTU2OTUwMTUzMDIyOTM5AAJTMQAA*?_action=validate",
        "href": "http://openam.example.com:8080/openam/json/sessions/AQIC5wM2LY4Sfcwu7reTddektA9rhw0Tzi_r-Wr1cHevSTM.*AAJTSQACMDEAAlNLABM3NTI2OTU2OTUwMTUzMDIyOTM5AAJTMQAA*?_action=validate"
      },
      "method": "POST",
      "headers": {
        "Content-Type": "application/json",
        "accept": "application/json",
        "content-length": 0
      }
    }
  }
}
```

I was able to figure out that this error is happening because `Accept-API-Version` needs to be either 1.1 or 1.2 (both work). In this PR it is 1.1



