### PR TITLE
Created configuration settings for Private IP and Hostname values

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -24,6 +24,8 @@ var fs = require('fs'),
  *
  * @param {object} options
  * @param {string} options.serverUrl The deployment URI of the OpenAM server, e.g. http://openam.example.com:8080/openam
+ * @param {string} options.privateIP The deployment IP of the OpenAM server, e.g. http://127.0.0.1:8080/openam
+ * @param {string} options.serverHost The deployment host of the OpenAM server, e.g. openam.example.com
  * @param {string} options.username Agent username (needed for certain operations, e.g. policy decision requests)
  * @param {string} options.password Agent password (needed for certain operations, e.g. policy decision requests)
  * @param {string} options.realm=/ Agent realm (needed for certain operations, e.g. policy decision requests)
@@ -74,6 +76,7 @@ var fs = require('fs'),
 function PolicyAgent(options) {
     var self = this;
     options.serverUrl = (options.serverUrl || '').replace(/\/$/, '');
+    options.privateIP = (options.privateIP || '').replace(/\/$/, '');
 
     /**
      * Config options
@@ -100,7 +103,7 @@ function PolicyAgent(options) {
      * OpenAM client used by the agent and its shields
      * @type {*|OpenAMClient}
      */
-    this.openAMClient = options.openAMClient || new OpenAMClient(options.serverUrl);
+    this.openAMClient = options.openAMClient || new OpenAMClient(options.serverUrl, options.serverHost, options.privateIP);
 
     /**
      * Logger

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -25,7 +25,6 @@ var fs = require('fs'),
  * @param {object} options
  * @param {string} options.serverUrl The deployment URI of the OpenAM server, e.g. http://openam.example.com:8080/openam
  * @param {string} options.privateIP The deployment IP of the OpenAM server, e.g. http://127.0.0.1:8080/openam
- * @param {string} options.serverHost The deployment host of the OpenAM server, e.g. openam.example.com
  * @param {string} options.username Agent username (needed for certain operations, e.g. policy decision requests)
  * @param {string} options.password Agent password (needed for certain operations, e.g. policy decision requests)
  * @param {string} options.realm=/ Agent realm (needed for certain operations, e.g. policy decision requests)
@@ -76,7 +75,6 @@ var fs = require('fs'),
 function PolicyAgent(options) {
     var self = this;
     options.serverUrl = (options.serverUrl || '').replace(/\/$/, '');
-    options.privateIP = (options.privateIP || '').replace(/\/$/, '');
 
     /**
      * Config options
@@ -103,7 +101,7 @@ function PolicyAgent(options) {
      * OpenAM client used by the agent and its shields
      * @type {*|OpenAMClient}
      */
-    this.openAMClient = options.openAMClient || new OpenAMClient(options.serverUrl, options.serverHost, options.privateIP);
+    this.openAMClient = options.openAMClient || new OpenAMClient(options.serverUrl, options.privateIP);
 
     /**
      * Logger

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -24,7 +24,7 @@ var fs = require('fs'),
  *
  * @param {object} options
  * @param {string} options.serverUrl The deployment URI of the OpenAM server, e.g. http://openam.example.com:8080/openam
- * @param {string} options.privateIP The deployment IP of the OpenAM server, e.g. http://127.0.0.1:8080/openam
+ * @param {string} options.privateIP The deployment IP of the OpenAM server, e.g. 127.0.0.1
  * @param {string} options.username Agent username (needed for certain operations, e.g. policy decision requests)
  * @param {string} options.password Agent password (needed for certain operations, e.g. policy decision requests)
  * @param {string} options.realm=/ Agent realm (needed for certain operations, e.g. policy decision requests)

--- a/lib/httpUtils.js
+++ b/lib/httpUtils.js
@@ -46,3 +46,22 @@ function getProtocol(req) {
 }
 
 module.exports.getProtocol = getProtocol;
+
+/**
+ * Returns "openam.example.com"
+ * @param url {string} http://openam.example.com:8080/openam
+ * @return {string}
+ */
+function getHostname(url) {
+    var hostname;
+    if (url.indexOf("://") > -1) {
+        hostname = url.split('/')[2];
+    }
+    else {
+        hostname = url.split('/')[0];    
+    }
+
+    return hostname.split(':')[0];
+}
+
+module.exports.getHostname = getHostname;

--- a/lib/httpUtils.js
+++ b/lib/httpUtils.js
@@ -46,22 +46,3 @@ function getProtocol(req) {
 }
 
 module.exports.getProtocol = getProtocol;
-
-/**
- * Returns "openam.example.com"
- * @param url {string} http://openam.example.com:8080/openam
- * @return {string}
- */
-function getHostname(url) {
-    var hostname;
-    if (url.indexOf("://") > -1) {
-        hostname = url.split('/')[2];
-    }
-    else {
-        hostname = url.split('/')[0];    
-    }
-
-    return hostname.split(':')[0];
-}
-
-module.exports.getHostname = getHostname;

--- a/lib/openam.js
+++ b/lib/openam.js
@@ -1,17 +1,23 @@
 var request = require('request-promise'),
     url = require('url'),
     shortid = require('shortid'),
-    Promise = require('bluebird');
+    Promise = require('bluebird'),
+    httpUtils = require('./httpUtils');
 
 /**
  * This class is used to access OpenAM APIs.
  * @param {string} serverUrl OpenAM server URL
  * @constructor
  */
-function OpenAMClient(serverUrl, serverHost, privateIP) {
+function OpenAMClient(serverUrl, privateIP) {
     this.serverUrl = serverUrl.replace(/\/$/, '');
-    this.serverHost = serverHost;
-    this.privateIP = privateIP.replace(/\/$/, '');
+    this.hostname = httpUtils.getHostname(this.serverUrl);
+    
+    if(privateIP){
+        this.serverAddress = this.serverUrl.replace(this.hostname, privateIP);
+    } else {
+        this.serverAddress = this.serverUrl;
+    }
 }
 
 /**
@@ -19,7 +25,7 @@ function OpenAMClient(serverUrl, serverHost, privateIP) {
  * @return {Promise} Server info
  */
 OpenAMClient.prototype.getServerInfo = function () {
-    return request.get((this.privateIP ? (this.privateIP) : (this.serverUrl)) + '/json/serverinfo/*', {headers:{host:this.serverHost}, json: true});
+    return request.get(this.serverAddress + '/json/serverinfo/*', {headers:{host:this.hostname}, json: true});
 };
 
 /**
@@ -46,9 +52,9 @@ OpenAMClient.prototype.authenticate = function (username, password, realm, servi
         authIndexValue = module;
     }
 
-    return request.post((this.privateIP ? (this.privateIP) : (this.serverUrl)) + '/json/authenticate', {
+    return request.post(this.serverAddress + '/json/authenticate', {
         headers: {
-            'host' : this.serverHost,
+            'host' : this.hostname,
             'X-OpenAM-Username': username,
             'X-OpenAM-Password': password
         },
@@ -71,9 +77,9 @@ OpenAMClient.prototype.logout = function (sessionId) {
     if (!sessionId)
         return Promise.resolve();
 
-    return request.post((this.privateIP ? (this.privateIP) : (this.serverUrl)) + '/identity/logout', {
+    return request.post(this.serverAddress + '/identity/logout', {
         headers: {
-            host: this.serverHost
+            host: this.hostname
         },
         form: {
             subjectid: sessionId
@@ -90,10 +96,10 @@ OpenAMClient.prototype.validateSession = function (sessionId) {
     if (!sessionId)
         return Promise.resolve({valid: false});
 
-    return request.post((this.privateIP ? (this.privateIP) : (this.serverUrl)) + '/json/sessions/' + sessionId, {
+    return request.post(this.serverAddress + '/json/sessions/' + sessionId, {
         qs: {_action: 'validate'},
         headers: {
-            'host': this.serverHost,
+            'host': this.hostname,
             'Content-Type': 'application/json',
             'Accept-API-Version': 'resource=1.1'
         },
@@ -150,8 +156,8 @@ OpenAMClient.prototype.getCDSSOUrl = function (target, provider) {
 OpenAMClient.prototype.getPolicyDecision = function (params, sessionId, cookieName) {
     var headers = {};
     headers[cookieName] = sessionId;
-    headers['host'] = this.serverHost; 
-    return request.post((this.privateIP ? (this.privateIP) : (this.serverUrl)) + '/json/policies', {
+    headers['host'] = this.hostname; 
+    return request.post(this.serverAddress + '/json/policies', {
         headers: headers,
         qs: {
             _action: 'evaluate'
@@ -168,9 +174,9 @@ OpenAMClient.prototype.getPolicyDecision = function (params, sessionId, cookieNa
  * @return {Promise} Session service response
  */
 OpenAMClient.prototype.sessionServiceRequest = function (requestSet) {
-    return request.post((this.privateIP ? (this.privateIP) : (this.serverUrl)) + '/sessionservice', {
+    return request.post(this.serverAddress + '/sessionservice', {
         headers: {
-            'host': this.serverHost,
+            'host': this.hostname,
             'Content-Type': 'text/xml'
         },
         body: requestSet
@@ -186,9 +192,9 @@ OpenAMClient.prototype.sessionServiceRequest = function (requestSet) {
  */
 OpenAMClient.prototype.validateAccessToken = function (accessToken, realm) {
     //noinspection JSValidateTypes
-    return request.get((this.privateIP ? (this.privateIP) : (this.serverUrl)) + '/oauth2/tokeninfo', {
+    return request.get(this.serverAddress + '/oauth2/tokeninfo', {
         headers: {
-            host: this.serverHost
+            host: this.hostname
         },
         qs: {
             access_token: accessToken,
@@ -208,9 +214,9 @@ OpenAMClient.prototype.validateAccessToken = function (accessToken, realm) {
  */
 OpenAMClient.prototype.getProfile = function (userId, realm, sessionId, cookieName) {
     //noinspection JSValidateTypes
-    return request.get((this.privateIP ? (this.privateIP) : (this.serverUrl)) + '/json/users/' + userId, {
+    return request.get(this.serverAddress + '/json/users/' + userId, {
         headers: {
-            host: this.serverHost,
+            host: this.hostname,
             cookie: cookieName + '=' + sessionId
         },
         qs: {

--- a/lib/openam.js
+++ b/lib/openam.js
@@ -150,7 +150,7 @@ OpenAMClient.prototype.getCDSSOUrl = function (target, provider) {
 OpenAMClient.prototype.getPolicyDecision = function (params, sessionId, cookieName) {
     var headers = {};
     headers[cookieName] = sessionId;
-    headers['host'] = this.serverHost;
+    headers['host'] = this.serverHost; 
     return request.post((this.privateIP ? (this.privateIP) : (this.serverUrl)) + '/json/policies', {
         headers: headers,
         qs: {

--- a/lib/openam.js
+++ b/lib/openam.js
@@ -48,7 +48,7 @@ OpenAMClient.prototype.authenticate = function (username, password, realm, servi
 
     return request.post((this.privateIP ? (this.privateIP) : (this.serverUrl)) + '/json/authenticate', {
         headers: {
-            'Host' : this.serverHost,
+            'host' : this.serverHost,
             'X-OpenAM-Username': username,
             'X-OpenAM-Password': password
         },
@@ -93,7 +93,7 @@ OpenAMClient.prototype.validateSession = function (sessionId) {
     return request.post((this.privateIP ? (this.privateIP) : (this.serverUrl)) + '/json/sessions/' + sessionId, {
         qs: {_action: 'validate'},
         headers: {
-            'Host': this.serverHost,
+            'host': this.serverHost,
             'Content-Type': 'application/json',
             'Accept-API-Version': 'resource=1.1'
         },
@@ -150,7 +150,7 @@ OpenAMClient.prototype.getCDSSOUrl = function (target, provider) {
 OpenAMClient.prototype.getPolicyDecision = function (params, sessionId, cookieName) {
     var headers = {};
     headers[cookieName] = sessionId;
-    headers[host] = this.serverHost;
+    headers['host'] = this.serverHost;
     return request.post((this.privateIP ? (this.privateIP) : (this.serverUrl)) + '/json/policies', {
         headers: headers,
         qs: {
@@ -170,7 +170,7 @@ OpenAMClient.prototype.getPolicyDecision = function (params, sessionId, cookieNa
 OpenAMClient.prototype.sessionServiceRequest = function (requestSet) {
     return request.post((this.privateIP ? (this.privateIP) : (this.serverUrl)) + '/sessionservice', {
         headers: {
-            'Host': this.serverHost,
+            'host': this.serverHost,
             'Content-Type': 'text/xml'
         },
         body: requestSet

--- a/lib/openam.js
+++ b/lib/openam.js
@@ -8,8 +8,10 @@ var request = require('request-promise'),
  * @param {string} serverUrl OpenAM server URL
  * @constructor
  */
-function OpenAMClient(serverUrl) {
+function OpenAMClient(serverUrl, serverHost, privateIP) {
     this.serverUrl = serverUrl.replace(/\/$/, '');
+    this.serverHost = serverHost;
+    this.privateIP = privateIP.replace(/\/$/, '');
 }
 
 /**
@@ -17,7 +19,7 @@ function OpenAMClient(serverUrl) {
  * @return {Promise} Server info
  */
 OpenAMClient.prototype.getServerInfo = function () {
-    return request.get(this.serverUrl + '/json/serverinfo/*', {json: true});
+    return request.get((this.privateIP ? (this.privateIP) : (this.serverUrl)) + '/json/serverinfo/*', {headers:{host:this.serverHost}, json: true});
 };
 
 /**
@@ -44,8 +46,9 @@ OpenAMClient.prototype.authenticate = function (username, password, realm, servi
         authIndexValue = module;
     }
 
-    return request.post(this.serverUrl + '/json/authenticate', {
+    return request.post((this.privateIP ? (this.privateIP) : (this.serverUrl)) + '/json/authenticate', {
         headers: {
+            'Host' : this.serverHost,
             'X-OpenAM-Username': username,
             'X-OpenAM-Password': password
         },
@@ -68,7 +71,10 @@ OpenAMClient.prototype.logout = function (sessionId) {
     if (!sessionId)
         return Promise.resolve();
 
-    return request.post(this.serverUrl + '/identity/logout', {
+    return request.post((this.privateIP ? (this.privateIP) : (this.serverUrl)) + '/identity/logout', {
+        headers: {
+            host: this.serverHost
+        },
         form: {
             subjectid: sessionId
         }
@@ -84,9 +90,10 @@ OpenAMClient.prototype.validateSession = function (sessionId) {
     if (!sessionId)
         return Promise.resolve({valid: false});
 
-    return request.post(this.serverUrl + '/json/sessions/' + sessionId, {
+    return request.post((this.privateIP ? (this.privateIP) : (this.serverUrl)) + '/json/sessions/' + sessionId, {
         qs: {_action: 'validate'},
         headers: {
+            'Host': this.serverHost,
             'Content-Type': 'application/json',
             'Accept-API-Version': 'resource=1.1'
         },
@@ -143,7 +150,8 @@ OpenAMClient.prototype.getCDSSOUrl = function (target, provider) {
 OpenAMClient.prototype.getPolicyDecision = function (params, sessionId, cookieName) {
     var headers = {};
     headers[cookieName] = sessionId;
-    return request.post(this.serverUrl + '/json/policies', {
+    headers[host] = this.serverHost;
+    return request.post((this.privateIP ? (this.privateIP) : (this.serverUrl)) + '/json/policies', {
         headers: headers,
         qs: {
             _action: 'evaluate'
@@ -160,8 +168,9 @@ OpenAMClient.prototype.getPolicyDecision = function (params, sessionId, cookieNa
  * @return {Promise} Session service response
  */
 OpenAMClient.prototype.sessionServiceRequest = function (requestSet) {
-    return request.post(this.serverUrl + '/sessionservice', {
+    return request.post((this.privateIP ? (this.privateIP) : (this.serverUrl)) + '/sessionservice', {
         headers: {
+            'Host': this.serverHost,
             'Content-Type': 'text/xml'
         },
         body: requestSet
@@ -177,7 +186,10 @@ OpenAMClient.prototype.sessionServiceRequest = function (requestSet) {
  */
 OpenAMClient.prototype.validateAccessToken = function (accessToken, realm) {
     //noinspection JSValidateTypes
-    return request.get(this.serverUrl + '/oauth2/tokeninfo', {
+    return request.get((this.privateIP ? (this.privateIP) : (this.serverUrl)) + '/oauth2/tokeninfo', {
+        headers: {
+            host: this.serverHost
+        },
         qs: {
             access_token: accessToken,
             realm: realm || '/'
@@ -196,8 +208,9 @@ OpenAMClient.prototype.validateAccessToken = function (accessToken, realm) {
  */
 OpenAMClient.prototype.getProfile = function (userId, realm, sessionId, cookieName) {
     //noinspection JSValidateTypes
-    return request.get(this.serverUrl + '/json/users/' + userId, {
+    return request.get((this.privateIP ? (this.privateIP) : (this.serverUrl)) + '/json/users/' + userId, {
         headers: {
+            host: this.serverHost,
             cookie: cookieName + '=' + sessionId
         },
         qs: {

--- a/lib/openam.js
+++ b/lib/openam.js
@@ -11,9 +11,9 @@ var request = require('request-promise'),
  */
 function OpenAMClient(serverUrl, privateIP) {
     this.serverUrl = serverUrl.replace(/\/$/, '');
-    this.hostname = httpUtils.getHostname(this.serverUrl);
     
     if(privateIP){
+        this.hostname = httpUtils.getHostname(this.serverUrl);
         this.serverAddress = this.serverUrl.replace(this.hostname, privateIP);
     } else {
         this.serverAddress = this.serverUrl;

--- a/lib/openam.js
+++ b/lib/openam.js
@@ -13,7 +13,7 @@ function OpenAMClient(serverUrl, privateIP) {
     this.serverUrl = serverUrl.replace(/\/$/, '');
     
     if(privateIP){
-        this.hostname = url.parse(this.serverUrl).hostname;;
+        this.hostname = url.parse(this.serverUrl).hostname;
         this.serverAddress = this.serverUrl.replace(this.hostname, privateIP);
     } else {
         this.serverAddress = this.serverUrl;

--- a/lib/openam.js
+++ b/lib/openam.js
@@ -2,7 +2,7 @@ var request = require('request-promise'),
     url = require('url'),
     shortid = require('shortid'),
     Promise = require('bluebird'),
-    httpUtils = require('./httpUtils');
+    url = require('url');
 
 /**
  * This class is used to access OpenAM APIs.
@@ -13,7 +13,7 @@ function OpenAMClient(serverUrl, privateIP) {
     this.serverUrl = serverUrl.replace(/\/$/, '');
     
     if(privateIP){
-        this.hostname = httpUtils.getHostname(this.serverUrl);
+        this.hostname = url.parse(this.serverUrl).hostname;;
         this.serverAddress = this.serverUrl.replace(this.hostname, privateIP);
     } else {
         this.serverAddress = this.serverUrl;

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "Agent"
   ],
   "dependencies": {
+    "assert": "^1.4.1",
     "basic-auth": "^1.0.3",
     "bluebird": "^3.4.6",
     "body-parser": "^1.13.3",

--- a/test/privateIP.js
+++ b/test/privateIP.js
@@ -3,17 +3,17 @@ var sinon = require('sinon'),
     request = require('request-promise'),
     OpenAMClient = require('../lib/openam').OpenAMClient;
 
-describe('PolicyAgent', function () {
-    var serverHost, serverUrl, privateIP;
+describe('Test with private IP', function () {
+    var hostname, serverUrl, privateIP;
 
     beforeEach(function () {
 
         serverUrl = 'http://openam.example.com:8080/openam';
-        serverHost = 'openam.example.com';
-        privateIP = 'http://127.0.0.1:8080/openam';
+        hostname = 'openam.example.com';
+        privateIP = '127.0.0.1';
 
         // client instance
-        client = new OpenAMClient(serverUrl, serverHost, privateIP);
+        client = new OpenAMClient(serverUrl, privateIP);
 
         // spies
         getRequests = sinon.spy(request, 'get');
@@ -28,51 +28,187 @@ describe('PolicyAgent', function () {
     });
 
     describe('getServerInfo', function () {
+        it('request should have private ip in url', function () {
+            client.getServerInfo();
+            assert.equal(request.get.getCall(0).args[0].includes(privateIP), true);
+        });
         it('request should have header host value', function () {
             client.getServerInfo();
-            assert.equal(request.get.getCall(0).args[1].headers.host, serverHost);
+            assert.equal(request.get.getCall(0).args[1].headers.host, hostname);
         });
     });
     describe('authenticate', function () {
+        it('request should have private ip in url', function () {
+            client.authenticate();
+            assert.equal(request.post.getCall(0).args[0].includes(privateIP), true);
+        });
         it('request should have header host value', function () {
             client.authenticate();
-            assert.equal(request.post.getCall(0).args[1].headers.host, serverHost);
+            assert.equal(request.post.getCall(0).args[1].headers.host, hostname);
         });
     });
     describe('logout', function () {
+        it('request should have private ip in url', function () {
+            client.logout('sessionid');
+            assert.equal(request.post.getCall(0).args[0].includes(privateIP), true);
+        });
         it('request should have header host value', function () {
-            client.logout('sessionID');
-            assert.equal(request.post.getCall(0).args[1].headers.host, serverHost);
+            client.logout('sessionid');
+            assert.equal(request.post.getCall(0).args[1].headers.host, hostname);
         });
     });
     describe('validateSession', function () {
+        it('request should have private ip in url', function () {
+            client.validateSession('sessionid');
+            assert.equal(request.post.getCall(0).args[0].includes(privateIP), true);
+        });
         it('request should have header host value', function () {
-            client.validateSession('sessionID');
-            assert.equal(request.post.getCall(0).args[1].headers.host, serverHost);
+            client.validateSession('sessionid');
+            assert.equal(request.post.getCall(0).args[1].headers.host, hostname);
         });
     });
     describe('getPolicyDecision', function () {
+        it('request should have private ip in url', function () {
+            client.getPolicyDecision(null, 'sessionId', 'cookieName');
+            assert.equal(request.post.getCall(0).args[0].includes(privateIP), true);
+        });
         it('request should have header host value', function () {
-            client.getPolicyDecision({},'sessionID', 'cookieName');
-            assert.equal(request.post.getCall(0).args[1].headers.host, serverHost);
+            client.getPolicyDecision(null, 'sessionId', 'cookieName');
+            assert.equal(request.post.getCall(0).args[1].headers.host, hostname);
         });
     });
     describe('sessionServiceRequest', function () {
+        it('request should have private ip in url', function () {
+            client.sessionServiceRequest('requestSet');
+            assert.equal(request.post.getCall(0).args[0].includes(privateIP), true);
+        });
         it('request should have header host value', function () {
-            client.sessionServiceRequest();
-            assert.equal(request.post.getCall(0).args[1].headers.host, serverHost);
+            client.sessionServiceRequest('requestSet');
+            assert.equal(request.post.getCall(0).args[1].headers.host, hostname);
         });
     });
     describe('validateAccessToken', function () {
+        it('request should have private ip in url', function () {
+            client.validateAccessToken('accessToken');
+            assert.equal(request.get.getCall(0).args[0].includes(privateIP), true);
+        });
         it('request should have header host value', function () {
-            client.validateAccessToken();
-            assert.equal(request.get.getCall(0).args[1].headers.host, serverHost);
+            client.validateAccessToken('accessToken');
+            assert.equal(request.get.getCall(0).args[1].headers.host, hostname);
         });
     });
     describe('getProfile', function () {
+        it('request should have private ip in url', function () {
+            client.getProfile('userId', 'realm', 'sessionId', 'cookieName');
+            assert.equal(request.get.getCall(0).args[0].includes(privateIP), true);
+        });
         it('request should have header host value', function () {
-            client.getProfile();
-            assert.equal(request.get.getCall(0).args[1].headers.host, serverHost);
+            client.getProfile('userId', 'realm', 'sessionId', 'cookieName');
+            assert.equal(request.get.getCall(0).args[1].headers.host, hostname);
+        });
+    });
+});
+describe('Test with private IP', function () {
+    var hostname, serverUrl;
+
+    beforeEach(function () {
+
+        serverUrl = 'http://openam.example.com:8080/openam';
+        hostname = 'openam.example.com';
+
+        // client instance
+        client = new OpenAMClient(serverUrl);
+
+        // spies
+        getRequests = sinon.spy(request, 'get');
+        postRequests = sinon.spy(request, 'post');
+
+    });
+
+    afterEach(function () {
+        // restore stubs
+        getRequests.restore();
+        postRequests.restore();
+    });
+
+    describe('getServerInfo', function () {
+        it('request should have serverUrl in url', function () {
+            client.getServerInfo();
+            assert.equal(request.get.getCall(0).args[0].includes(serverUrl), true);
+        });
+        it('request should have header host value', function () {
+            client.getServerInfo();
+            assert.equal(request.get.getCall(0).args[1].headers.host, hostname);
+        });
+    });
+    describe('authenticate', function () {
+        it('request should have serverUrl in url', function () {
+            client.authenticate();
+            assert.equal(request.post.getCall(0).args[0].includes(serverUrl), true);
+        });
+        it('request should have header host value', function () {
+            client.authenticate();
+            assert.equal(request.post.getCall(0).args[1].headers.host, hostname);
+        });
+    });
+    describe('logout', function () {
+        it('request should have serverUrl in url', function () {
+            client.logout('sessionid');
+            assert.equal(request.post.getCall(0).args[0].includes(serverUrl), true);
+        });
+        it('request should have header host value', function () {
+            client.logout('sessionid');
+            assert.equal(request.post.getCall(0).args[1].headers.host, hostname);
+        });
+    });
+    describe('validateSession', function () {
+        it('request should have serverUrl in url', function () {
+            client.validateSession('sessionid');
+            assert.equal(request.post.getCall(0).args[0].includes(serverUrl), true);
+        });
+        it('request should have header host value', function () {
+            client.validateSession('sessionid');
+            assert.equal(request.post.getCall(0).args[1].headers.host, hostname);
+        });
+    });
+    describe('getPolicyDecision', function () {
+        it('request should have serverUrl in url', function () {
+            client.getPolicyDecision(null, 'sessionId', 'cookieName');
+            assert.equal(request.post.getCall(0).args[0].includes(serverUrl), true);
+        });
+        it('request should have header host value', function () {
+            client.getPolicyDecision(null, 'sessionId', 'cookieName');
+            assert.equal(request.post.getCall(0).args[1].headers.host, hostname);
+        });
+    });
+    describe('sessionServiceRequest', function () {
+        it('request should have serverUrl in url', function () {
+            client.sessionServiceRequest('requestSet');
+            assert.equal(request.post.getCall(0).args[0].includes(serverUrl), true);
+        });
+        it('request should have header host value', function () {
+            client.sessionServiceRequest('requestSet');
+            assert.equal(request.post.getCall(0).args[1].headers.host, hostname);
+        });
+    });
+    describe('validateAccessToken', function () {
+        it('request should have serverUrl in url', function () {
+            client.validateAccessToken('accessToken');
+            assert.equal(request.get.getCall(0).args[0].includes(serverUrl), true);
+        });
+        it('request should have header host value', function () {
+            client.validateAccessToken('accessToken');
+            assert.equal(request.get.getCall(0).args[1].headers.host, hostname);
+        });
+    });
+    describe('getProfile', function () {
+        it('request should have serverUrl in url', function () {
+            client.getProfile('userId', 'realm', 'sessionId', 'cookieName');
+            assert.equal(request.get.getCall(0).args[0].includes(serverUrl), true);
+        });
+        it('request should have header host value', function () {
+            client.getProfile('userId', 'realm', 'sessionId', 'cookieName');
+            assert.equal(request.get.getCall(0).args[1].headers.host, hostname);
         });
     });
 });

--- a/test/privateIP.js
+++ b/test/privateIP.js
@@ -136,9 +136,9 @@ describe('Test without private IP', function () {
             client.getServerInfo();
             assert.equal(request.get.getCall(0).args[0].includes(serverUrl), true);
         });
-        it('request should have header host value', function () {
+        it('request should not have header host value', function () {
             client.getServerInfo();
-            assert.equal(request.get.getCall(0).args[1].headers.host, hostname);
+            assert.equal(request.get.getCall(0).args[1].headers.host, undefined);
         });
     });
     describe('authenticate', function () {
@@ -146,49 +146,49 @@ describe('Test without private IP', function () {
             client.authenticate();
             assert.equal(request.post.getCall(0).args[0].includes(serverUrl), true);
         });
-        it('request should have header host value', function () {
+        it('request should not have header host value', function () {
             client.authenticate();
-            assert.equal(request.post.getCall(0).args[1].headers.host, hostname);
+            assert.equal(request.post.getCall(0).args[1].headers.host, undefined);
         });
     });
     describe('logout', function () {
-        it('request should have serverUrl in url', function () {
+        it('request should not have serverUrl in url', function () {
             client.logout('sessionid');
             assert.equal(request.post.getCall(0).args[0].includes(serverUrl), true);
         });
-        it('request should have header host value', function () {
+        it('request should not have header host value', function () {
             client.logout('sessionid');
-            assert.equal(request.post.getCall(0).args[1].headers.host, hostname);
+            assert.equal(request.post.getCall(0).args[1].headers.host, undefined);
         });
     });
     describe('validateSession', function () {
-        it('request should have serverUrl in url', function () {
+        it('request should not have serverUrl in url', function () {
             client.validateSession('sessionid');
             assert.equal(request.post.getCall(0).args[0].includes(serverUrl), true);
         });
-        it('request should have header host value', function () {
+        it('request should not have header host value', function () {
             client.validateSession('sessionid');
-            assert.equal(request.post.getCall(0).args[1].headers.host, hostname);
+            assert.equal(request.post.getCall(0).args[1].headers.host, undefined);
         });
     });
     describe('getPolicyDecision', function () {
-        it('request should have serverUrl in url', function () {
+        it('request should not have serverUrl in url', function () {
             client.getPolicyDecision({}, 'sessionID', 'cookieName');
             assert.equal(request.post.getCall(0).args[0].includes(serverUrl), true);
         });
-        it('request should have header host value', function () {
+        it('request should not have header host value', function () {
             client.getPolicyDecision({}, 'sessionID', 'cookieName');
-            assert.equal(request.post.getCall(0).args[1].headers.host, hostname);
+            assert.equal(request.post.getCall(0).args[1].headers.host, undefined);
         });
     });
     describe('sessionServiceRequest', function () {
-        it('request should have serverUrl in url', function () {
+        it('request should not have serverUrl in url', function () {
             client.sessionServiceRequest();
             assert.equal(request.post.getCall(0).args[0].includes(serverUrl), true);
         });
-        it('request should have header host value', function () {
+        it('request should not have header host value', function () {
             client.sessionServiceRequest();
-            assert.equal(request.post.getCall(0).args[1].headers.host, hostname);
+            assert.equal(request.post.getCall(0).args[1].headers.host, undefined);
         });
     });
     describe('validateAccessToken', function () {
@@ -196,9 +196,9 @@ describe('Test without private IP', function () {
             client.validateAccessToken();
             assert.equal(request.get.getCall(0).args[0].includes(serverUrl), true);
         });
-        it('request should have header host value', function () {
+        it('request should not have header host value', function () {
             client.validateAccessToken();
-            assert.equal(request.get.getCall(0).args[1].headers.host, hostname);
+            assert.equal(request.get.getCall(0).args[1].headers.host, undefined);
         });
     });
     describe('getProfile', function () {
@@ -206,9 +206,9 @@ describe('Test without private IP', function () {
             client.getProfile();
             assert.equal(request.get.getCall(0).args[0].includes(serverUrl), true);
         });
-        it('request should have header host value', function () {
+        it('request should not have header host value', function () {
             client.getProfile();
-            assert.equal(request.get.getCall(0).args[1].headers.host, hostname);
+            assert.equal(request.get.getCall(0).args[1].headers.host, undefined);
         });
     });
 });

--- a/test/privateIP.js
+++ b/test/privateIP.js
@@ -53,7 +53,7 @@ describe('PolicyAgent', function () {
     });
     describe('getPolicyDecision', function () {
         it('request should have header host value', function () {
-            client.getPolicyDecision({},'sessionID', 'cookieName')
+            client.getPolicyDecision({},'sessionID', 'cookieName')git 
             assert.equal(request.post.getCall(0).args[1].headers.host, serverHost)
         });
     });

--- a/test/privateIP.js
+++ b/test/privateIP.js
@@ -13,7 +13,7 @@ describe('Test with private IP', function () {
         privateIP = '127.0.0.1';
 
         // client instance
-        client = new OpenAMClient(serverUrl, privateIP);
+        clientIP = new OpenAMClient(serverUrl, privateIP);
 
         // spies
         getRequests = sinon.spy(request, 'get');
@@ -29,92 +29,91 @@ describe('Test with private IP', function () {
 
     describe('getServerInfo', function () {
         it('request should have private ip in url', function () {
-            client.getServerInfo();
+            clientIP.getServerInfo();
             assert.equal(request.get.getCall(0).args[0].includes(privateIP), true);
         });
         it('request should have header host value', function () {
-            client.getServerInfo();
+            clientIP.getServerInfo();
             assert.equal(request.get.getCall(0).args[1].headers.host, hostname);
         });
     });
     describe('authenticate', function () {
         it('request should have private ip in url', function () {
-            client.authenticate();
+            clientIP.authenticate();
             assert.equal(request.post.getCall(0).args[0].includes(privateIP), true);
         });
         it('request should have header host value', function () {
-            client.authenticate();
+            clientIP.authenticate();
             assert.equal(request.post.getCall(0).args[1].headers.host, hostname);
         });
     });
     describe('logout', function () {
         it('request should have private ip in url', function () {
-            client.logout('sessionid');
+            clientIP.logout('sessionid');
             assert.equal(request.post.getCall(0).args[0].includes(privateIP), true);
         });
         it('request should have header host value', function () {
-            client.logout('sessionid');
+            clientIP.logout('sessionid');
             assert.equal(request.post.getCall(0).args[1].headers.host, hostname);
         });
     });
     describe('validateSession', function () {
         it('request should have private ip in url', function () {
-            client.validateSession('sessionid');
+            clientIP.validateSession('sessionid');
             assert.equal(request.post.getCall(0).args[0].includes(privateIP), true);
         });
         it('request should have header host value', function () {
-            client.validateSession('sessionid');
+            clientIP.validateSession('sessionid');
             assert.equal(request.post.getCall(0).args[1].headers.host, hostname);
         });
     });
     describe('getPolicyDecision', function () {
         it('request should have private ip in url', function () {
-            client.getPolicyDecision({}, 'sessionId', 'cookieName');
+            clientIP.getPolicyDecision({}, 'sessionId', 'cookieName');
             assert.equal(request.post.getCall(0).args[0].includes(privateIP), true);
         });
         it('request should have header host value', function () {
-            client.getPolicyDecision({}, 'sessionId', 'cookieName');
+            clientIP.getPolicyDecision({}, 'sessionId', 'cookieName');
             assert.equal(request.post.getCall(0).args[1].headers.host, hostname);
         });
     });
     describe('sessionServiceRequest', function () {
         it('request should have private ip in url', function () {
-            client.sessionServiceRequest();
+            clientIP.sessionServiceRequest();
             assert.equal(request.post.getCall(0).args[0].includes(privateIP), true);
         });
         it('request should have header host value', function () {
-            client.sessionServiceRequest();
+            clientIP.sessionServiceRequest();
             assert.equal(request.post.getCall(0).args[1].headers.host, hostname);
         });
     });
     describe('validateAccessToken', function () {
         it('request should have private ip in url', function () {
-            client.validateAccessToken();
+            clientIP.validateAccessToken();
             assert.equal(request.get.getCall(0).args[0].includes(privateIP), true);
         });
         it('request should have header host value', function () {
-            client.validateAccessToken();
+            clientIP.validateAccessToken();
             assert.equal(request.get.getCall(0).args[1].headers.host, hostname);
         });
     });
     describe('getProfile', function () {
         it('request should have private ip in url', function () {
-            client.getProfile();
+            clientIP.getProfile();
             assert.equal(request.get.getCall(0).args[0].includes(privateIP), true);
         });
         it('request should have header host value', function () {
-            client.getProfile();
+            clientIP.getProfile();
             assert.equal(request.get.getCall(0).args[1].headers.host, hostname);
         });
     });
 });
 describe('Test without private IP', function () {
-    var hostname, serverUrl;
+    var serverUrl;
 
     beforeEach(function () {
 
         serverUrl = 'http://openam.example.com:8080/openam';
-        hostname = 'openam.example.com';
 
         // client instance
         client = new OpenAMClient(serverUrl);

--- a/test/privateIP.js
+++ b/test/privateIP.js
@@ -69,21 +69,21 @@ describe('Test with private IP', function () {
     });
     describe('getPolicyDecision', function () {
         it('request should have private ip in url', function () {
-            client.getPolicyDecision(null, 'sessionId', 'cookieName');
+            client.getPolicyDecision({}, 'sessionId', 'cookieName');
             assert.equal(request.post.getCall(0).args[0].includes(privateIP), true);
         });
         it('request should have header host value', function () {
-            client.getPolicyDecision(null, 'sessionId', 'cookieName');
+            client.getPolicyDecision({}, 'sessionId', 'cookieName');
             assert.equal(request.post.getCall(0).args[1].headers.host, hostname);
         });
     });
     describe('sessionServiceRequest', function () {
         it('request should have private ip in url', function () {
-            client.sessionServiceRequest('requestSet');
+            client.sessionServiceRequest();
             assert.equal(request.post.getCall(0).args[0].includes(privateIP), true);
         });
         it('request should have header host value', function () {
-            client.sessionServiceRequest('requestSet');
+            client.sessionServiceRequest();
             assert.equal(request.post.getCall(0).args[1].headers.host, hostname);
         });
     });
@@ -173,21 +173,21 @@ describe('Test without private IP', function () {
     });
     describe('getPolicyDecision', function () {
         it('request should have serverUrl in url', function () {
-            client.getPolicyDecision(null, 'sessionId', 'cookieName');
+            client.getPolicyDecision({}, 'sessionId', 'cookieName');
             assert.equal(request.post.getCall(0).args[0].includes(serverUrl), true);
         });
         it('request should have header host value', function () {
-            client.getPolicyDecision(null, 'sessionId', 'cookieName');
+            client.getPolicyDecision({}, 'sessionId', 'cookieName');
             assert.equal(request.post.getCall(0).args[1].headers.host, hostname);
         });
     });
     describe('sessionServiceRequest', function () {
         it('request should have serverUrl in url', function () {
-            client.sessionServiceRequest('requestSet');
+            client.sessionServiceRequest();
             assert.equal(request.post.getCall(0).args[0].includes(serverUrl), true);
         });
         it('request should have header host value', function () {
-            client.sessionServiceRequest('requestSet');
+            client.sessionServiceRequest();
             assert.equal(request.post.getCall(0).args[1].headers.host, hostname);
         });
     });

--- a/test/privateIP.js
+++ b/test/privateIP.js
@@ -15,9 +15,9 @@ describe('Test with private IP', function () {
         // client instance
         clientIP = new OpenAMClient(serverUrl, privateIP);
 
-        // spies
-        getRequests = sinon.spy(request, 'get');
-        postRequests = sinon.spy(request, 'post');
+        // stubs
+        getRequests = sinon.stub(request, 'get');
+        postRequests = sinon.stub(request, 'post');
 
     });
 
@@ -118,9 +118,9 @@ describe('Test without private IP', function () {
         // client instance
         client = new OpenAMClient(serverUrl);
 
-        // spies
-        getRequests = sinon.spy(request, 'get');
-        postRequests = sinon.spy(request, 'post');
+        // stubs
+        getRequests = sinon.stub(request, 'get');
+        postRequests = sinon.stub(request, 'post');
 
     });
 

--- a/test/privateIP.js
+++ b/test/privateIP.js
@@ -89,21 +89,21 @@ describe('Test with private IP', function () {
     });
     describe('validateAccessToken', function () {
         it('request should have private ip in url', function () {
-            client.validateAccessToken('accessToken');
+            client.validateAccessToken();
             assert.equal(request.get.getCall(0).args[0].includes(privateIP), true);
         });
         it('request should have header host value', function () {
-            client.validateAccessToken('accessToken');
+            client.validateAccessToken();
             assert.equal(request.get.getCall(0).args[1].headers.host, hostname);
         });
     });
     describe('getProfile', function () {
         it('request should have private ip in url', function () {
-            client.getProfile('userId', 'realm', 'sessionId', 'cookieName');
+            client.getProfile();
             assert.equal(request.get.getCall(0).args[0].includes(privateIP), true);
         });
         it('request should have header host value', function () {
-            client.getProfile('userId', 'realm', 'sessionId', 'cookieName');
+            client.getProfile();
             assert.equal(request.get.getCall(0).args[1].headers.host, hostname);
         });
     });
@@ -173,11 +173,11 @@ describe('Test without private IP', function () {
     });
     describe('getPolicyDecision', function () {
         it('request should have serverUrl in url', function () {
-            client.getPolicyDecision({}, 'sessionId', 'cookieName');
+            client.getPolicyDecision({}, 'sessionID', 'cookieName');
             assert.equal(request.post.getCall(0).args[0].includes(serverUrl), true);
         });
         it('request should have header host value', function () {
-            client.getPolicyDecision({}, 'sessionId', 'cookieName');
+            client.getPolicyDecision({}, 'sessionID', 'cookieName');
             assert.equal(request.post.getCall(0).args[1].headers.host, hostname);
         });
     });
@@ -193,21 +193,21 @@ describe('Test without private IP', function () {
     });
     describe('validateAccessToken', function () {
         it('request should have serverUrl in url', function () {
-            client.validateAccessToken('accessToken');
+            client.validateAccessToken();
             assert.equal(request.get.getCall(0).args[0].includes(serverUrl), true);
         });
         it('request should have header host value', function () {
-            client.validateAccessToken('accessToken');
+            client.validateAccessToken();
             assert.equal(request.get.getCall(0).args[1].headers.host, hostname);
         });
     });
     describe('getProfile', function () {
         it('request should have serverUrl in url', function () {
-            client.getProfile('userId', 'realm', 'sessionId', 'cookieName');
+            client.getProfile();
             assert.equal(request.get.getCall(0).args[0].includes(serverUrl), true);
         });
         it('request should have header host value', function () {
-            client.getProfile('userId', 'realm', 'sessionId', 'cookieName');
+            client.getProfile();
             assert.equal(request.get.getCall(0).args[1].headers.host, hostname);
         });
     });

--- a/test/privateIP.js
+++ b/test/privateIP.js
@@ -29,50 +29,50 @@ describe('PolicyAgent', function () {
 
     describe('getServerInfo', function () {
         it('request should have header host value', function () {
-            client.getServerInfo()
-            assert.equal(request.get.getCall(0).args[1].headers.host, serverHost)
+            client.getServerInfo();
+            assert.equal(request.get.getCall(0).args[1].headers.host, serverHost);
         });
     });
     describe('authenticate', function () {
         it('request should have header host value', function () {
-            client.authenticate()
-            assert.equal(request.post.getCall(0).args[1].headers.host, serverHost)
+            client.authenticate();
+            assert.equal(request.post.getCall(0).args[1].headers.host, serverHost);
         });
     });
     describe('logout', function () {
         it('request should have header host value', function () {
-            client.logout('sessionID')
-            assert.equal(request.post.getCall(0).args[1].headers.host, serverHost)
+            client.logout('sessionID');
+            assert.equal(request.post.getCall(0).args[1].headers.host, serverHost);
         });
     });
     describe('validateSession', function () {
         it('request should have header host value', function () {
-            client.validateSession('sessionID')
-            assert.equal(request.post.getCall(0).args[1].headers.host, serverHost)
+            client.validateSession('sessionID');
+            assert.equal(request.post.getCall(0).args[1].headers.host, serverHost);
         });
     });
     describe('getPolicyDecision', function () {
         it('request should have header host value', function () {
-            client.getPolicyDecision({},'sessionID', 'cookieName')git 
-            assert.equal(request.post.getCall(0).args[1].headers.host, serverHost)
+            client.getPolicyDecision({},'sessionID', 'cookieName');
+            assert.equal(request.post.getCall(0).args[1].headers.host, serverHost);
         });
     });
     describe('sessionServiceRequest', function () {
         it('request should have header host value', function () {
-            client.sessionServiceRequest()
-            assert.equal(request.post.getCall(0).args[1].headers.host, serverHost)
+            client.sessionServiceRequest();
+            assert.equal(request.post.getCall(0).args[1].headers.host, serverHost);
         });
     });
     describe('validateAccessToken', function () {
         it('request should have header host value', function () {
-            client.validateAccessToken()
-            assert.equal(request.get.getCall(0).args[1].headers.host, serverHost)
+            client.validateAccessToken();
+            assert.equal(request.get.getCall(0).args[1].headers.host, serverHost);
         });
     });
     describe('getProfile', function () {
         it('request should have header host value', function () {
-            client.getProfile()
-            assert.equal(request.get.getCall(0).args[1].headers.host, serverHost)
+            client.getProfile();
+            assert.equal(request.get.getCall(0).args[1].headers.host, serverHost);
         });
     });
 });

--- a/test/privateIP.js
+++ b/test/privateIP.js
@@ -30,7 +30,7 @@ describe('Test with private IP', function () {
     describe('getServerInfo', function () {
         it('request should have private ip in url', function () {
             clientIP.getServerInfo();
-            assert.equal(request.get.getCall(0).args[0].includes(privateIP), true);
+            assert.equal((request.get.getCall(0).args[0].indexOf(privateIP) > -1), true);
         });
         it('request should have header host value', function () {
             clientIP.getServerInfo();
@@ -40,7 +40,7 @@ describe('Test with private IP', function () {
     describe('authenticate', function () {
         it('request should have private ip in url', function () {
             clientIP.authenticate();
-            assert.equal(request.post.getCall(0).args[0].includes(privateIP), true);
+            assert.equal((request.post.getCall(0).args[0].indexOf(privateIP) > -1), true);
         });
         it('request should have header host value', function () {
             clientIP.authenticate();
@@ -50,7 +50,7 @@ describe('Test with private IP', function () {
     describe('logout', function () {
         it('request should have private ip in url', function () {
             clientIP.logout('sessionid');
-            assert.equal(request.post.getCall(0).args[0].includes(privateIP), true);
+            assert.equal((request.post.getCall(0).args[0].indexOf(privateIP) > -1), true);
         });
         it('request should have header host value', function () {
             clientIP.logout('sessionid');
@@ -60,7 +60,7 @@ describe('Test with private IP', function () {
     describe('validateSession', function () {
         it('request should have private ip in url', function () {
             clientIP.validateSession('sessionid');
-            assert.equal(request.post.getCall(0).args[0].includes(privateIP), true);
+            assert.equal((request.post.getCall(0).args[0].indexOf(privateIP) > -1), true);
         });
         it('request should have header host value', function () {
             clientIP.validateSession('sessionid');
@@ -70,7 +70,7 @@ describe('Test with private IP', function () {
     describe('getPolicyDecision', function () {
         it('request should have private ip in url', function () {
             clientIP.getPolicyDecision({}, 'sessionId', 'cookieName');
-            assert.equal(request.post.getCall(0).args[0].includes(privateIP), true);
+            assert.equal((request.post.getCall(0).args[0].indexOf(privateIP) > -1), true);
         });
         it('request should have header host value', function () {
             clientIP.getPolicyDecision({}, 'sessionId', 'cookieName');
@@ -80,7 +80,7 @@ describe('Test with private IP', function () {
     describe('sessionServiceRequest', function () {
         it('request should have private ip in url', function () {
             clientIP.sessionServiceRequest();
-            assert.equal(request.post.getCall(0).args[0].includes(privateIP), true);
+            assert.equal((request.post.getCall(0).args[0].indexOf(privateIP) > -1), true);
         });
         it('request should have header host value', function () {
             clientIP.sessionServiceRequest();
@@ -90,7 +90,7 @@ describe('Test with private IP', function () {
     describe('validateAccessToken', function () {
         it('request should have private ip in url', function () {
             clientIP.validateAccessToken();
-            assert.equal(request.get.getCall(0).args[0].includes(privateIP), true);
+            assert.equal((request.get.getCall(0).args[0].indexOf(privateIP) > -1), true);
         });
         it('request should have header host value', function () {
             clientIP.validateAccessToken();
@@ -100,7 +100,7 @@ describe('Test with private IP', function () {
     describe('getProfile', function () {
         it('request should have private ip in url', function () {
             clientIP.getProfile();
-            assert.equal(request.get.getCall(0).args[0].includes(privateIP), true);
+            assert.equal((request.get.getCall(0).args[0].indexOf(privateIP) > -1), true);
         });
         it('request should have header host value', function () {
             clientIP.getProfile();
@@ -133,7 +133,7 @@ describe('Test without private IP', function () {
     describe('getServerInfo', function () {
         it('request should have serverUrl in url', function () {
             client.getServerInfo();
-            assert.equal(request.get.getCall(0).args[0].includes(serverUrl), true);
+            assert.equal((request.get.getCall(0).args[0].indexOf(serverUrl) > -1), true);
         });
         it('request should not have header host value', function () {
             client.getServerInfo();
@@ -143,7 +143,7 @@ describe('Test without private IP', function () {
     describe('authenticate', function () {
         it('request should have serverUrl in url', function () {
             client.authenticate();
-            assert.equal(request.post.getCall(0).args[0].includes(serverUrl), true);
+            assert.equal((request.post.getCall(0).args[0].indexOf(serverUrl) > -1), true);
         });
         it('request should not have header host value', function () {
             client.authenticate();
@@ -153,7 +153,7 @@ describe('Test without private IP', function () {
     describe('logout', function () {
         it('request should not have serverUrl in url', function () {
             client.logout('sessionid');
-            assert.equal(request.post.getCall(0).args[0].includes(serverUrl), true);
+            assert.equal((request.post.getCall(0).args[0].indexOf(serverUrl) > -1), true);
         });
         it('request should not have header host value', function () {
             client.logout('sessionid');
@@ -163,7 +163,7 @@ describe('Test without private IP', function () {
     describe('validateSession', function () {
         it('request should not have serverUrl in url', function () {
             client.validateSession('sessionid');
-            assert.equal(request.post.getCall(0).args[0].includes(serverUrl), true);
+            assert.equal((request.post.getCall(0).args[0].indexOf(serverUrl) > -1), true);
         });
         it('request should not have header host value', function () {
             client.validateSession('sessionid');
@@ -173,7 +173,7 @@ describe('Test without private IP', function () {
     describe('getPolicyDecision', function () {
         it('request should not have serverUrl in url', function () {
             client.getPolicyDecision({}, 'sessionID', 'cookieName');
-            assert.equal(request.post.getCall(0).args[0].includes(serverUrl), true);
+            assert.equal((request.post.getCall(0).args[0].indexOf(serverUrl) > -1), true);
         });
         it('request should not have header host value', function () {
             client.getPolicyDecision({}, 'sessionID', 'cookieName');
@@ -183,7 +183,7 @@ describe('Test without private IP', function () {
     describe('sessionServiceRequest', function () {
         it('request should not have serverUrl in url', function () {
             client.sessionServiceRequest();
-            assert.equal(request.post.getCall(0).args[0].includes(serverUrl), true);
+            assert.equal((request.post.getCall(0).args[0].indexOf(serverUrl) > -1), true);
         });
         it('request should not have header host value', function () {
             client.sessionServiceRequest();
@@ -193,7 +193,7 @@ describe('Test without private IP', function () {
     describe('validateAccessToken', function () {
         it('request should have serverUrl in url', function () {
             client.validateAccessToken();
-            assert.equal(request.get.getCall(0).args[0].includes(serverUrl), true);
+            assert.equal((request.get.getCall(0).args[0].indexOf(serverUrl) > -1), true);
         });
         it('request should not have header host value', function () {
             client.validateAccessToken();
@@ -203,7 +203,7 @@ describe('Test without private IP', function () {
     describe('getProfile', function () {
         it('request should have serverUrl in url', function () {
             client.getProfile();
-            assert.equal(request.get.getCall(0).args[0].includes(serverUrl), true);
+            assert.equal((request.get.getCall(0).args[0].indexOf(serverUrl) > -1), true);
         });
         it('request should not have header host value', function () {
             client.getProfile();

--- a/test/privateIP.js
+++ b/test/privateIP.js
@@ -89,11 +89,11 @@ describe('Test with private IP', function () {
     });
     describe('validateAccessToken', function () {
         it('request should have private ip in url', function () {
-            clientIP.validateAccessToken();
+            clientIP.validateAccessToken('accessToken');
             assert.equal((request.get.getCall(0).args[0].indexOf(privateIP) > -1), true);
         });
         it('request should have header host value', function () {
-            clientIP.validateAccessToken();
+            clientIP.validateAccessToken('accessToken');
             assert.equal(request.get.getCall(0).args[1].headers.host, hostname);
         });
     });
@@ -192,11 +192,11 @@ describe('Test without private IP', function () {
     });
     describe('validateAccessToken', function () {
         it('request should have serverUrl in url', function () {
-            client.validateAccessToken();
+            client.validateAccessToken('accessToken');
             assert.equal((request.get.getCall(0).args[0].indexOf(serverUrl) > -1), true);
         });
         it('request should not have header host value', function () {
-            client.validateAccessToken();
+            client.validateAccessToken('accessToken');
             assert.equal(request.get.getCall(0).args[1].headers.host, undefined);
         });
     });

--- a/test/privateIP.js
+++ b/test/privateIP.js
@@ -108,7 +108,7 @@ describe('Test with private IP', function () {
         });
     });
 });
-describe('Test with private IP', function () {
+describe('Test without private IP', function () {
     var hostname, serverUrl;
 
     beforeEach(function () {

--- a/test/privateIP.js
+++ b/test/privateIP.js
@@ -17,7 +17,7 @@ describe('PolicyAgent', function () {
             logLevel: 'none', // suppress logs for tests
             serverUrl: 'http://openam.example.com:8080/openam',
             serverHost: 'openam.example.com:',
-            privateIP: 'https://127.0.0.1:8080/openam'
+            privateIP: 'http://127.0.0.1:8080/openam'
         };
 
         // agent instance

--- a/test/privateIP.js
+++ b/test/privateIP.js
@@ -1,0 +1,122 @@
+var fs = require('fs'),
+    should = require('should'),
+    sinon = require('sinon'),
+    request = require('request-promise'),
+    openamAgent = require('../lib'),
+    PolicyAgent = require('../lib/agent').PolicyAgent,
+    SimpleCache = require('openam-agent-cache-simple').SimpleCache;
+
+require('should-sinon');
+
+describe('PolicyAgent', function () {
+    var agent, otions, resolve, stubRequest = {};
+
+    beforeEach(function () {
+        options = {
+            noInit: true,
+            logLevel: 'none', // suppress logs for tests
+            serverUrl: 'http://openam.example.com:8080/openam',
+            serverHost: 'openam.example.com:',
+            privateIP: 'https://127.0.0.1:8080/openam'
+        };
+
+        // agent instance
+        agent = new PolicyAgent(options);
+
+        // spies
+        resolve = sinon.spy();
+
+        // stubs
+        stubRequest.get = sinon.stub(request, 'get', function () {
+            return Promise.resolve();
+        });
+        stubRequest.post = sinon.stub(request, 'post', function () {
+            return Promise.resolve();
+        });
+    });
+
+    afterEach(function () {
+        // restore stubs
+        request.get.restore();
+        request.post.restore();
+    });
+
+    it('should set the options', function () {
+        should(agent.options).be.equal(options);
+    });
+
+    it('should have a random ID', function () {
+        should(agent.id.match(/[a-z0-9]+/i)).not.be.null();
+    });
+
+    it('should have an OpenAMClient instance', function () {
+        should(agent.openAMClient instanceof openamAgent.OpenAMClient).be.true();
+    });
+
+    it('should have a session cache instance', function () {
+        should(agent.sessionCache instanceof SimpleCache).be.true();
+    });
+
+    describe('serverInfo', function () {
+        it('should be a resolved promise', function () {
+            should(agent.serverInfo).be.Promise();
+            agent.serverInfo.then(resolve);
+            return agent.serverInfo.then(function () {
+                resolve.should.be.called();
+            });
+        });
+    });
+
+    describe('agentSession', function () {
+        it('should be a resolved promise', function () {
+            should(agent.agentSession).be.Promise();
+            agent.agentSession.then(resolve);
+            return agent.agentSession.then(function () {
+                resolve.should.be.called();
+            });
+        });
+    });
+
+    it('should remove destroyed sessions on session events', function (done) {
+        var sessionData = {foo: 'bar'};
+
+        agent.on('session', function () {
+            should(agent.sessionCache._keyValueStore.mock).be.undefined();
+            done();
+        });
+
+        agent.sessionCache.put('mock', sessionData);
+        agent.sessionCache.get('mock').then(function (data) {
+            data.should.be.equal(sessionData);
+            agent.emit('session', {state: 'destroyed', sid: 'mock'});
+        });
+    });
+
+    describe('init', function () {
+        it('should get the server info', function () {
+            agent.init();
+            stubRequest.get.should.be.calledWith(options.privateIP + '/json/serverinfo/*');
+        });
+    });
+
+    describe('.getSessionIdFromLARES()', function () {
+        it('should resolve the promise with the session ID if the CDSSO Assertion (LARES) is valid', function () {
+            var lares = fs.readFileSync(__dirname + '/resources/validLARES.txt').toString();
+            return agent.getSessionIdFromLARES(lares)
+                .then(function (sessionId) {
+                    should(sessionId).be.equal('foo');
+                });
+        });
+        it('should reject the promise if the CDSSO Assertion (LARES) is invalid', function () {
+            var lares = fs.readFileSync(__dirname + '/resources/expiredLARES.txt').toString();
+
+            return agent.getSessionIdFromLARES(lares)
+                .then(function (sessionId) {
+                    should(sessionId).be.equal(null);
+                }).catch(function (err) {
+                    should(err).not.be.equal(undefined);
+                    should(err).not.be.equal(null);
+                });
+        });
+    });
+});


### PR DESCRIPTION
I currently had an issue where our openam server is only accessable using a private internal ip address. Since openam must use a FQDN I couldn't just access the server via http://private-IP:8080/openam instead i needed to go to http://FQDN:8080/openam. The issue here was the request-promise module ignores the /etc/hosts file for the private ip and get the public ip from the dnsname server. The public ip for the server forces the request through the corporate proxy, going through the proxy to access the openam server blocks the openam server. 

The change I made was adding two additional config options: serverHost and privateIP

**serverHost** (optional) example value 'openam.myhost.com' This is added to the header on all the openam.js get and post requests. Omitting this value causes the app to behave exactly the same as it did before. 

**privateIP** (optional) example value 'http://127.0.0.1:8080/openam' This value is used in the openam.js file. All request gets and posts do a conditional statement that checks if the privateIP has a value, if not it uses the serverURL. Omitting this value causes the app to behave exactly the same as it did before. 
